### PR TITLE
feat: upgrade CDK to v2.222.0 and PostgreSQL to v15.10 LTS

### DIFF
--- a/lib/application-plane/cell-app-plane/cdk/lib/RdsPostgresConstruct.ts
+++ b/lib/application-plane/cell-app-plane/cdk/lib/RdsPostgresConstruct.ts
@@ -79,7 +79,7 @@ import {
 
         // Declaring postgres engine
         let auroraEngine = rds.DatabaseClusterEngine.auroraPostgres({
-        version: rds.AuroraPostgresEngineVersion.VER_15_4,
+        version: rds.AuroraPostgresEngineVersion.VER_15_10,
         });
 
         let auroraParameters: any = {};

--- a/lib/application-plane/cell-app-plane/cdk/package.json
+++ b/lib/application-plane/cell-app-plane/cdk/package.json
@@ -13,15 +13,15 @@
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/node": "22.10.1",
-    "aws-cdk": "2.1018.1",
+    "aws-cdk": "2.1031.1",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.5",
     "ts-node": "^10.9.2",
     "typescript": "~5.5.3"
   },
   "dependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "2.201.0-alpha.0",
-    "aws-cdk-lib": "2.201.0",
+    "@aws-cdk/aws-lambda-python-alpha": "2.222.0-alpha.0",
+    "aws-cdk-lib": "2.222.0",
     "constructs": "^10.0.0",
     "cdk-nag": "2.36.18",
     "source-map-support": "^0.5.21"

--- a/package.json
+++ b/package.json
@@ -13,15 +13,15 @@
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/node": "22.10.1",
-    "aws-cdk": "2.1018.1",
+    "aws-cdk": "2.1031.1",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.5",
     "ts-node": "^10.9.2",
     "typescript": "~5.5.3"
   },
   "dependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "2.201.0-alpha.0",
-    "aws-cdk-lib": "2.201.0",
+    "@aws-cdk/aws-lambda-python-alpha": "2.222.0-alpha.0",
+    "aws-cdk-lib": "2.222.0",
     "constructs": "^10.0.0",
     "cdk-nag": "2.36.18"
   }


### PR DESCRIPTION
- Upgrade aws-cdk-lib from 2.201.0 to 2.222.0 (+21 versions)
- Upgrade aws-cdk CLI from 2.1018.1 to 2.1031.1 (+13 versions)
- Upgrade Aurora PostgreSQL from 15.4 to 15.10 (LTS)
- Ensure consistent CDK versions across all projects
- Improve security and stability with latest patches

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
